### PR TITLE
Draft of the adapter interface

### DIFF
--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -1,17 +1,15 @@
 package adapter
 
-type Adapter interface {
-	Next() (Handleable, error)
-}
-
-type Handleable interface {
-	Type() (HandleableType)
-}
-
-type HandleableType string
-
-const (
-	CMD HandleableType = "command"
-	QRY = "query"
+import (
+	"github.com/domain-query-language/dql-server/src/server/vm/handler/command"
+	"github.com/domain-query-language/dql-server/src/server/vm/handler/query"
 )
+
+type CommandAdapter interface {
+	Next() (command.Command, error)
+}
+
+type QueryAdapter interface {
+	Next() (query.Query, error)
+}
 

--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -12,6 +12,6 @@ type HandleableType string
 
 const (
 	CMD HandleableType = "command"
-	EVT  = "event"
+	QRY = "query"
 )
 

--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -1,0 +1,17 @@
+package adapter
+
+type Adapter interface {
+	Next() (Handleable, error)
+}
+
+type Handleable interface {
+	Type() (HandleableType)
+}
+
+type HandleableType string
+
+const (
+	CMD HandleableType = "command"
+	EVT  = "event"
+)
+


### PR DESCRIPTION
Here is the first draft of the adapter interface.

It returns a handleable object (command or query), or an error.

The adapter can return zero or more handleable objects, as the string it's parsing could contain more than one command/query.