### PR TITLE
Updated the Adapter interface to make things clearer and more useful

### DIFF
--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -10,11 +10,11 @@ type Adapter interface {
 }
 
 // Make it easy to get the correct type out, no need for casting based on "HandleableType"
-type Handleable interface {
+type Handleable struct {
 
-	Type() HandleableType
-	Command() handler.Command
-	Query() handler.Query
+	typ HandleableType
+	command handler.Command
+	query handler.Query
 }
 
 type HandleableType string
@@ -24,37 +24,14 @@ const (
 	QRY = "query"
 )
 
-// Simple implementation
-type SimpleHandleable struct {
-
-	typ HandleableType
-	cmd handler.Command
-	qry handler.Query
-}
-
-func (h *SimpleHandleable) Type() {
-
-	return h.typ;
-}
-
-func (h *SimpleHandleable) Command() handler.Command {
-
-	return h.cmd
-}
-
-func (h *SimpleHandleable) Query() handler.Query {
-
-	return h.qry
-}
-
 // Helper methods to make creating it easier
-func NewCommand(cmd handler.Command) Handleable {
+func NewCommand(cmd handler.Command) *Handleable {
 
-	return &SimpleHandleable{CMD, cmd, nil}
+	return &Handleable{CMD, cmd, nil}
 }
 
-func NewQuery(qry handler.Query) Handleable {
+func NewQuery(qry handler.Query) *Handleable {
 
-	return &SimpleHandleable{QRY, qry, nil}
+	return &Handleable{QRY, qry, nil}
 }
 

--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -12,9 +12,9 @@ type Adapter interface {
 // Make it easy to get the correct type out, no need for casting based on "HandleableType"
 type Handleable struct {
 
-	typ HandleableType
-	command handler.Command
-	query handler.Query
+	Typ HandleableType
+	Command handler.Command
+	Query handler.Query
 }
 
 type HandleableType string
@@ -32,6 +32,6 @@ func NewCommand(cmd handler.Command) *Handleable {
 
 func NewQuery(qry handler.Query) *Handleable {
 
-	return &Handleable{QRY, qry, nil}
+	return &Handleable{QRY, nil, qry}
 }
 

--- a/src/server/adapter/adapter.go
+++ b/src/server/adapter/adapter.go
@@ -1,15 +1,60 @@
 package adapter
 
 import (
-	"github.com/domain-query-language/dql-server/src/server/vm/handler/command"
-	"github.com/domain-query-language/dql-server/src/server/vm/handler/query"
+	"github.com/domain-query-language/dql-server/src/server/vm/handler"
 )
 
-type CommandAdapter interface {
-	Next() (command.Command, error)
+type Adapter interface {
+
+	Next() (Handleable, error)
 }
 
-type QueryAdapter interface {
-	Next() (query.Query, error)
+// Make it easy to get the correct type out, no need for casting based on "HandleableType"
+type Handleable interface {
+
+	Type() HandleableType
+	Command() handler.Command
+	Query() handler.Query
+}
+
+type HandleableType string
+
+const (
+	CMD HandleableType = "command"
+	QRY = "query"
+)
+
+// Simple implementation
+type SimpleHandleable struct {
+
+	typ HandleableType
+	cmd handler.Command
+	qry handler.Query
+}
+
+func (h *SimpleHandleable) Type() {
+
+	return h.typ;
+}
+
+func (h *SimpleHandleable) Command() handler.Command {
+
+	return h.cmd
+}
+
+func (h *SimpleHandleable) Query() handler.Query {
+
+	return h.qry
+}
+
+// Helper methods to make creating it easier
+func NewCommand(cmd handler.Command) Handleable {
+
+	return &SimpleHandleable{CMD, cmd, nil}
+}
+
+func NewQuery(qry handler.Query) Handleable {
+
+	return &SimpleHandleable{QRY, qry, nil}
 }
 

--- a/src/server/vm/handler/query.go
+++ b/src/server/vm/handler/query.go
@@ -1,0 +1,5 @@
+package handler
+
+type Query interface {
+
+}

--- a/tests/server/adapter/handleable_test.go
+++ b/tests/server/adapter/handleable_test.go
@@ -1,0 +1,61 @@
+package adapter
+
+import (
+	"testing"
+	"github.com/domain-query-language/dql-server/src/server/adapter"
+	"github.com/domain-query-language/dql-server/src/server/vm/handler"
+)
+
+type FakeCommand struct {}
+
+func (c *FakeCommand) Id() handler.Identifier {
+	return nil
+}
+
+func (c *FakeCommand) TypeId() handler.Identifier {
+	return nil
+}
+
+func TestTypesAreCorrectForCommand(t *testing.T) {
+
+	cmd := &FakeCommand{};
+	hndlr := adapter.NewCommand( cmd );
+
+	if (hndlr.Typ != adapter.CMD) {
+		t.Error("Expected command, got query");
+	}
+
+	if (hndlr.Query != nil) {
+		t.Error("Query should be nil")
+	}
+
+	if (hndlr.Command == nil) {
+		t.Error("Command should not be nil")
+	}
+
+	if (hndlr.Command != cmd) {
+		t.Error("Commands should be equal");
+	}
+}
+
+func TestTypesAreCorrectForQuery(t *testing.T) {
+
+	qry := &struct{}{};
+	hndlr := adapter.NewQuery( qry );
+
+	if (hndlr.Typ != adapter.QRY) {
+		t.Error("Expected query, got command");
+	}
+
+	if (hndlr.Command != nil) {
+		t.Error("Command should be nil")
+	}
+
+	if (hndlr.Query == nil) {
+		t.Error("Query should not be nil")
+	}
+
+	if (hndlr.Query != qry) {
+		t.Error("Queries should be equal");
+	}
+}


### PR DESCRIPTION
Based on our discussion yesterday, I've moved back to a single interface "Adapter" that will have different implementations, depending on whether it's schema or domain.

I've re-introduced to the Handleable, but made it a struct, it was originally an interface, but the interface was just getters, so a struct made more sense.

I've added a placeholder query interface to "vm/handler", just so I could test the "handleable" concept.

It can hold a reference to either query or command, so there's no need for casting. You just check the value of "typ", then access the appropriate property.

There are also some helper constructor functions, they'll be used internally in the adapter building the command/query objects.